### PR TITLE
router.errorResponder and router.joiOpts added

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ server.get({
   next()
 })
 
+server.get({
+  path: '/anythingErr/:id',
+  validation: {
+    params: Joi.object().keys({
+      id: Joi.number().min(0).required()
+    }).required()
+  },
+  errorResponder (transformedErr, req, res, next) {
+    req.ifError = transformedErr
+    return next()
+  }
+}, (req, res, next) => {
+  res.send(200, {err: req.ifError})
+  next()
+})
+
 server.post({
   path: '/',
   validation: {
@@ -60,6 +76,21 @@ server.post({
   }
 }, (req, res, next) => {
   res.send(201, {id: 1, name: req.body.name})
+  next()
+})
+
+server.post({
+  path: '/anything',
+  joiOpts: {
+    allowUnknown: true
+  },
+  validation: {
+    body: Joi.object().keys({
+      name: Joi.string().required()
+    }).required()
+  }
+}, (req, res, next) => {
+  res.send(201, {params: req.params})
   next()
 })
 
@@ -105,10 +136,10 @@ server.use(validator({
 }, {
   // changes the request keys validated
   keysToValidate: ['params', 'body', 'query', 'user', 'headers', 'trailers', 'files'],
-  
+
   // changes how joi errors are transformed to be returned - no details are returned in this case
   errorTransformer: (validationInput, joiError) => new restifyErrors.BadRequestError(),
-  
+
   // changes how errors are returned
   errorResponder: (transformedErr, req, res, next) => {
     res.send(400, transformedErr)

--- a/example/server.js
+++ b/example/server.js
@@ -26,6 +26,22 @@ server.get({
   next()
 })
 
+server.get({
+  path: '/anythingErr/:id',
+  validation: {
+    params: Joi.object().keys({
+      id: Joi.number().min(0).required()
+    }).required()
+  },
+  errorResponder (transformedErr, req, res, next) {
+    req.ifError = transformedErr
+    return next()
+  }
+}, (req, res, next) => {
+  res.send(200, {err: req.ifError})
+  next()
+})
+
 server.post({
   path: '/',
   validation: {
@@ -35,6 +51,21 @@ server.post({
   }
 }, (req, res, next) => {
   res.send(201, {id: 1, name: req.body.name})
+  next()
+})
+
+server.post({
+  path: '/anything',
+  joiOpts: {
+    allowUnknown: true
+  },
+  validation: {
+    body: Joi.object().keys({
+      name: Joi.string().required()
+    }).required()
+  }
+}, (req, res, next) => {
+  res.send(201, {params: req.params})
   next()
 })
 

--- a/tests/joiOptionsTests.js
+++ b/tests/joiOptionsTests.js
@@ -89,3 +89,28 @@ test('validation preserves additional values present in the input when the conve
     t.end()
   })
 })
+
+test('when the route.joiOptions option is set, validation ignore options main ' +
+  'for which validation is defined', t => {
+  const req = {
+    params: {
+      id: '2',
+      name: 'Test'
+    },
+    route: {
+      joiOpts: {
+        allowUnknown: false
+      },
+      validation: {
+        params: {
+          id: Joi.number().required()
+        }
+      }
+    }
+  }
+  middleware({allowUnknown: true})(req, {send: t.fail}, err => {
+    t.ok(err, 'Returns and error')
+    t.equal(err.statusCode, 400, 'Error has a statusCode of 400')
+    t.end()
+  })
+})

--- a/tests/optionsTests.js
+++ b/tests/optionsTests.js
@@ -56,3 +56,31 @@ test('options.errorResponder alters how the middleware responds to errors', t =>
     t.end()
   })
 })
+
+test('route.errorResponder allows define transformation of the error in ' +
+  'the response middleware', t => {
+  const responder = (transformedErr, req, res, next) => {
+    req.errorResponder = transformedErr
+    return next()
+  }
+
+  const req = {
+    params: {
+      id: 'test'
+    },
+    route: {
+      validation: {
+        params: {
+          id: Joi.number().required()
+        }
+      },
+      errorResponder: responder
+    }
+  }
+
+  middleware({allowUnknown: true}, {})(req, {}, () => {})
+
+  t.ok(req.errorResponder, 'An error should be returned')
+  t.equal(req.errorResponder.statusCode, 400, 'Error has a statusCode of 400')
+  t.end()
+})


### PR DESCRIPTION
### Transforms errors
Config route
```javascript
  server.post({
    path: '/change_password',
    validation: {
      body: Joi.object().keys({
        password: Joi.string().required(),
        password_confirmation: Joi.any().valid(Joi.ref('password')).required()
      }).required()
    },
    errorResponder (transformedErr, req, res, next) { // <-- here
      req.ifError = transformedErr
      return next()
    }
  },
  controller.change)
```
Middleware
```javascript
  export const change = (req, res, next) => {
    res.render('passwords/errors.pug', { errors: req.ifError.body })
  }
```

### Change the joi options to a specific route.

Config server
```javascript
  server.use(validator({
    allowUnknown: false
  }, {})
```
Config route
```javascript
  server.post({
    path: '/change_password',
    validation: {
      body: Joi.object().keys({
        password: Joi.string().required(),
        password_confirmation: Joi.any().valid(Joi.ref('password')).required()
      }).required()
    },
    joiOpts: { allowUnknown: true } // <-- here
  },
  controller.change)
```